### PR TITLE
chore: bypass cla checks in merge queue

### DIFF
--- a/.github/workflows/cla_template.yml
+++ b/.github/workflows/cla_template.yml
@@ -24,6 +24,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            if (context.eventName === "merge_group" || context.payload.merge_group) {
+              core.info("Merge group event detected; skipping CLA checks.");
+              core.setOutput('author', 'merge_group');
+              core.setOutput('is_internal', 'yes');
+              core.setOutput('org_member', 'yes');
+              core.setOutput('checked_contributors', JSON.stringify([]));
+              core.setOutput('cla_statuses', JSON.stringify([]));
+              core.setOutput('missing_cla', JSON.stringify([]));
+              core.setOutput('team_names', JSON.stringify([]));
+              core.setOutput('team_members', JSON.stringify({}));
+              core.setOutput('org_used', process.env.CLA_ORG || context.repo.owner);
+              return;
+            }
             const pr = context.payload.pull_request;
             const author = pr.user.login;
             const claApiUrl = process.env.CLA_API_URL;


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
When the CLA check is required in a repository, it only needs to run when the merge queue is entered.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x]  Update the workflow to pass if the merge queue is detected.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
