### PR TITLE
feat: add CLA workflow caller

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,21 @@
+---
+name: CLA Workflow
+
+permissions:
+  contents: write
+  checks: write
+  actions: write
+  pull-requests: write
+
+on:
+  merge_group:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - master
+
+jobs:
+  cla:
+    uses: clima/.github/.github/workflows/cla_template.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Purpose 

This PR introduces an automated Contributor License Agreement (CLA) check. External contributors must agree to the CLA once via a lightweight GitHub-authenticated flow before their PRs can be merged. The check runs automatically on pull requests and blocks the merge only if a required CLA is missing.

CLA text: https://ecodesign.clima.caltech.edu/cla/download/

How to sign: authenticate with GitHub, type your name, and click the “I agree” button.

(Caltech, MIT, JPL Employees and automated bots are not affected.)

Closes #16 

## To-do
- [x] Add the CLA workflow caller

## Content
- Added `.github/workflows/cla.yml` using the organization template.

----
- [x] I have read and checked the items on the review checklist.