### PR TITLE
fix: ignore CLA users case-insensitively

### DIFF
--- a/.github/workflows/cla_template.yml
+++ b/.github/workflows/cla_template.yml
@@ -46,7 +46,15 @@ jobs:
               "dependabot[bot]",
             ]);
 
-            if (ignoredUsers.has(author) || author.endsWith("[bot]")) {
+            const isIgnoredUser = (username) => {
+              if (!username) {
+                return false;
+              }
+              const normalizedUsername = username.toLowerCase();
+              return ignoredUsers.has(normalizedUsername) || normalizedUsername.endsWith("[bot]");
+            };
+
+            if (isIgnoredUser(author)) {
               core.info(`Skipping CLA check for system user: ${author}`);
               core.setOutput('author', author);
               core.setOutput('is_internal', 'yes');
@@ -171,7 +179,7 @@ jobs:
               if (!username) {
                 return;
               }
-              if (ignoredUsers.has(username) || username.endsWith("[bot]")) {
+              if (isIgnoredUser(username)) {
                 core.info(`Skipping ignored/bot user ${username} from ${source}`);
                 return;
               }


### PR DESCRIPTION
## Purpose

Fix CLA failures caused by ignored users appearing with different username casing, such as `Copilot`.

## To-do

- [ ] Confirm the CLA workflow passes on the affected PR after merge, if applicable.

## Content

- Added an `isIgnoredUser` helper that normalizes usernames to lowercase before checking the ignored-user list.
- Updated the PR-author bypass to use the helper.
- Updated contributor collection filtering to use the helper.
- Preserved existing ignored users and bot filtering behavior.

----
- [x] I have read and checked the items on the review checklist.